### PR TITLE
fix: Vim theme parser and right color scopes

### DIFF
--- a/crates/sss_code/src/theme/parser.rs
+++ b/crates/sss_code/src/theme/parser.rs
@@ -16,7 +16,7 @@ pub fn parse_vim(vim: &str) -> HashMap<&str, VimHighlight> {
             let style = values
                 .next()
                 .and_then(|v| (!v.is_empty()).then_some(v.to_string()));
-            (name, (bg, fg, style))
+            (name, (fg, bg, style))
         })
         .collect::<HashMap<&str, VimHighlight>>()
 }
@@ -27,18 +27,18 @@ const VIM_NAMES: [(&str, &str); 19] = [
     ("String", "string"),
     ("Constant", "constant"),
     ("Identifier", "variable"),
-    ("Keyword", "keyword"),
+    ("Keyword", "keyword, storage"),
     ("Comment", "comment"),
     ("Operator", "keyword.operator, operator"),
     ("Statement", "variable.parameter.function"),
-    ("Type", "entity.name.class, meta.class, support.class, type, typeParameter, entity.type.name, entity.name.type, meta.type.name, storage"),
+    ("Type", "entity.name.class, meta.class, support.class, type, typeParameter, entity.type.name, entity.name.type, meta.type.name"),
     ("Structure", "enum, struct"),
-    ("StorageClass", "storage"),
+    ("StorageClass", "support"),
     ("Function", "entity.name.function, support.function, function"),
     ("Macro", "macro, entity.name.function.macro"),
     ("TSField", "property"),
     ("TSParameter", "parameter"),
-    ("parens", "brace"),
+    ("Delimiter", "brace"),
     ("Conditional", "conditional, keyword.conditional, keyword.control.conditional"),
     ("MyTag", "brackethighlighter.tag, brackethighlighter.angle, brackethighlighter.round, brackethighlighter.square"),
 ];

--- a/crates/sss_code/src/theme/vim.rs
+++ b/crates/sss_code/src/theme/vim.rs
@@ -54,8 +54,8 @@ pub fn theme_from_vim(vim: &str) -> Theme {
     Theme {
         scopes,
         settings: ThemeSettings {
-            foreground: fg_n,
-            background: bg_n,
+            foreground: fg_n.or(Some(syntect::highlighting::Color::WHITE)),
+            background: bg_n.or(Some(syntect::highlighting::Color::BLACK)),
             caret: bg_cur,
             line_highlight: bg_cur_line,
             misspelling: fg_bad,


### PR DESCRIPTION
# Vim theme
Vim theme has been parsed wrong, before this pr it was using `bg` as `fg` and vice versa, now it is correctly setted.
Before, when creating the theme is needed to have `bg` and `fg` in `Normal` highlight, but someone that doesn't want to set 
it and just use the default colors (`fg: #FFFFFF`, `bg: #000000`) can't use this. Now, `fg` and `bg` fallbacks to the 
default colors mentioned before.

# Syntax scheme
There're a few colors that are linked wrong taking nvim from reference.

```rust
struct A;
// ^
```

This is highlighted with `StorageClass`. This means to a class (`A`), but it should be a `Keyword`.
There's repeated `storage` scope, is in `StorageClass` and `Type`, now it is only in `Keyword`