### PR TITLE
Optional output arg

### DIFF
--- a/crates/sss_code/src/config.rs
+++ b/crates/sss_code/src/config.rs
@@ -52,13 +52,18 @@ pub struct CodeConfig {
     #[clap(
         long,
         short = 'l',
-        conflicts_with = "list_themes",
+        conflicts_with_all = &[ "list_themes", "output" ],
         help = "Lists supported file types"
     )]
     #[merge(strategy = overwrite_false)]
     #[serde(skip)]
     pub list_file_types: bool,
-    #[clap(long, short = 'L', help = "Lists themes")]
+    #[clap(
+        long,
+        short = 'L', 
+        conflicts_with = "output",
+        help = "Lists themes"
+    )]
     #[merge(strategy = overwrite_false)]
     #[serde(skip)]
     pub list_themes: bool,

--- a/crates/sss_lib/src/args.rs
+++ b/crates/sss_lib/src/args.rs
@@ -84,7 +84,7 @@ pub struct GenerationSettingsArgs {
         help = "[values: raw or file path] If it is set then the result will be saved here"
     )]
     #[serde(skip)]
-    #[clap(required_unless_present_any = &["list_themes", "list_file_types"])]
+    #[clap(required = true)]
     pub output: Option<String>,
     #[clap(
         long,

--- a/crates/sss_lib/src/args.rs
+++ b/crates/sss_lib/src/args.rs
@@ -166,7 +166,7 @@ impl From<GenerationSettingsArgs> for GenerationSettings {
         GenerationSettings {
             copy: val.copy,
             show_notify: val.show_notify,
-            output: val.output.clone().unwrap_or(String::from("")),
+            output: val.output.clone().unwrap_or_default(),
             save_format: val.save_format.clone(),
             colors: val.colors.into(),
             padding: (val.padding_x.unwrap_or(80), val.padding_y.unwrap_or(100)),

--- a/crates/sss_lib/src/args.rs
+++ b/crates/sss_lib/src/args.rs
@@ -84,7 +84,7 @@ pub struct GenerationSettingsArgs {
         help = "[values: raw or file path] If it is set then the result will be saved here"
     )]
     #[serde(skip)]
-    #[clap(required_unless_present = "list_themes")]
+    #[clap(required_unless_present_any = &["list_themes", "list_file_types"])]
     pub output: Option<String>,
     #[clap(
         long,

--- a/crates/sss_lib/src/args.rs
+++ b/crates/sss_lib/src/args.rs
@@ -84,7 +84,8 @@ pub struct GenerationSettingsArgs {
         help = "[values: raw or file path] If it is set then the result will be saved here"
     )]
     #[serde(skip)]
-    pub output: String,
+    #[clap(required_unless_present = "list_themes")]
+    pub output: Option<String>,
     #[clap(
         long,
         short = 'f',
@@ -165,7 +166,7 @@ impl From<GenerationSettingsArgs> for GenerationSettings {
         GenerationSettings {
             copy: val.copy,
             show_notify: val.show_notify,
-            output: val.output.clone(),
+            output: val.output.clone().unwrap_or(String::from("")),
             save_format: val.save_format.clone(),
             colors: val.colors.into(),
             padding: (val.padding_x.unwrap_or(80), val.padding_y.unwrap_or(100)),

--- a/crates/sss_lib/src/args.rs
+++ b/crates/sss_lib/src/args.rs
@@ -166,7 +166,7 @@ impl From<GenerationSettingsArgs> for GenerationSettings {
         GenerationSettings {
             copy: val.copy,
             show_notify: val.show_notify,
-            output: val.output.clone().unwrap_or_default(),
+            output: val.output.clone().unwrap_or(String::from("out.png")),
             save_format: val.save_format.clone(),
             colors: val.colors.into(),
             padding: (val.padding_x.unwrap_or(80), val.padding_y.unwrap_or(100)),


### PR DESCRIPTION
This pull request change a little how works the CLI of sss_code, instead of have ``--output`` argument as obligatory when you try list themes or file types (``--list-themes and`` and ``list-file-types``) this pass to be optional, for example:

Before this been obligatory:
```bash
sss_code --list-themes --output raw # Or
sss_code --list-files-types --output raw 

# Can be a file path instead of "raw"
``` 
Now you can do this without problems: 
```bash
sss_code --list-files-types # Or also do
sss_code --list-themes
```