### PR TITLE
fix: typo

### DIFF
--- a/crates/sss_cli/Cargo.toml
+++ b/crates/sss_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sss_cli"
-description = "Take pretty screenshot to your screen"
+description = "Take pretty screenshots to your screen"
 version = "0.1.5"
 publish = false
 default-run = "sss"

--- a/crates/sss_code/Cargo.toml
+++ b/crates/sss_code/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sss_code"
-description = "Take pretty screenshot to your code"
+description = "Take pretty screenshots to your code"
 version = "0.1.9"
 publish = false
 authors.workspace = true


### PR DESCRIPTION
This PR solves #47, only adds 2 `s`, on each cargo toml this way fixing the typo on the website.