### PR TITLE
[Code] Add indent and hidden characters render

### DIFF
--- a/crates/sss_code/src/config.rs
+++ b/crates/sss_code/src/config.rs
@@ -1,5 +1,6 @@
 use std::ops::Range;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use clap::Parser;
 use clap_stdin::FileOrStdin;
@@ -23,6 +24,29 @@ struct ClapConfig {
     #[clap(flatten)]
     #[serde(rename = "general")]
     pub lib_config: sss_lib::GenerationSettingsArgs,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub enum HiddenCharType {
+    Space,
+    Tab,
+    EOL,
+}
+
+impl FromStr for HiddenCharType {
+    type Err = CodeScreenshotError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "space" => Ok(HiddenCharType::Space),
+            "tab" => Ok(HiddenCharType::Tab),
+            "eol" => Ok(HiddenCharType::EOL),
+            _ => Err(CodeScreenshotError::InvalidFormat(
+                "Hidden Character",
+                "space:·,tab:»,eol:¶",
+            )),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Merge, Parser, Serialize)]
@@ -94,6 +118,9 @@ pub struct CodeConfig {
     #[clap(long, short = 'i', help = "Indent characters (separated by comma)", num_args = 0.., value_delimiter = ',')]
     #[merge(strategy = append)]
     pub indent_chars: Vec<char>,
+    #[clap(long, help = "Show Hidden Characters", num_args = 0.., value_delimiter = ',', value_parser = parse_hidden_character_type)]
+    #[merge(strategy = append)]
+    pub hidden_chars: Vec<(HiddenCharType, char)>,
 }
 
 impl Default for CodeConfig {
@@ -119,6 +146,7 @@ impl Default for CodeConfig {
             line_numbers: true,
             tab_width: Some(4),
             indent_chars: Vec::new(),
+            hidden_chars: Vec::new(),
         }
     }
 }
@@ -149,6 +177,15 @@ pub fn get_config() -> Result<(CodeConfig, sss_lib::GenerationSettings), Configu
         return Ok((config.code.unwrap_or_default(), config.lib_config.into()));
     }
     Ok((args.code.unwrap_or_default(), args.lib_config.into()))
+}
+
+fn parse_hidden_character_type(s: &str) -> Result<(HiddenCharType, char), CodeScreenshotError> {
+    let (ty, val) = s.split_once(':').ok_or(CodeScreenshotError::InvalidFormat(
+        "Hidden Character",
+        "TYPE:char,",
+    ))?;
+
+    Ok((HiddenCharType::from_str(ty)?, val.chars().next().unwrap()))
 }
 
 fn parse_range(s: &str) -> Result<Range<usize>, CodeScreenshotError> {

--- a/crates/sss_code/src/config.rs
+++ b/crates/sss_code/src/config.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use clap_stdin::FileOrStdin;
-use merge2::{bool::overwrite_false, option::recursive, Merge};
+use merge2::{bool::overwrite_false, option::recursive, vec::append, Merge};
 use serde::{Deserialize, Serialize};
 use sss_lib::{default_bool, swap_option};
 
@@ -91,6 +91,9 @@ pub struct CodeConfig {
     #[clap(long, help = "Tab width")]
     #[merge(strategy = swap_option)]
     pub tab_width: Option<u8>,
+    #[clap(long, short = 'i', help = "Indent characters (separated by comma)", num_args = 0.., value_delimiter = ',')]
+    #[merge(strategy = append)]
+    pub indent_chars: Vec<char>,
 }
 
 impl Default for CodeConfig {
@@ -115,6 +118,7 @@ impl Default for CodeConfig {
             }),
             line_numbers: true,
             tab_width: Some(4),
+            indent_chars: Vec::new(),
         }
     }
 }

--- a/crates/sss_code/src/utils.rs
+++ b/crates/sss_code/src/utils.rs
@@ -20,3 +20,84 @@ pub fn fontstyle_from_syntect(style: HiFontStyle) -> FontStyle {
         FontStyle::Regular
     }
 }
+
+pub fn process_token_text<F>(
+    text: &str,
+    space: char,
+    tab_char: char,
+    tab_size: usize,
+    in_indent: &mut bool,
+    mut indent_level: usize,
+    get_indent_char: F,
+) -> (String, usize)
+where
+    F: Fn(usize) -> char,
+{
+    let mut result = String::with_capacity(text.len());
+    let mut consecutive_spaces = 0;
+
+    for c in text.chars() {
+        match c {
+            ' ' => {
+                consecutive_spaces += 1;
+                if consecutive_spaces == tab_size {
+                    if *in_indent {
+                        result.push(get_indent_char(indent_level));
+                        for _ in 0..tab_size - 1 {
+                            result.push(tab_char);
+                        }
+                        indent_level += 1;
+                    } else {
+                        for _ in 0..tab_size {
+                            result.push(space);
+                        }
+                    }
+                    consecutive_spaces = 0;
+                }
+            }
+            '\t' => {
+                if *in_indent {
+                    result.push(get_indent_char(indent_level));
+                    for _ in 0..tab_size - 1 {
+                        result.push(tab_char);
+                    }
+                    indent_level += 1;
+                } else {
+                    result.push(tab_char);
+                }
+                consecutive_spaces = 0;
+            }
+            _ => {
+                if consecutive_spaces > 0 {
+                    if *in_indent {
+                        for _ in 0..consecutive_spaces {
+                            result.push(tab_char);
+                        }
+                    } else {
+                        for _ in 0..consecutive_spaces {
+                            result.push(space);
+                        }
+                    }
+                    consecutive_spaces = 0;
+                }
+                result.push(c);
+                *in_indent = false; // Cambiamos a false después de encontrar un carácter no indentable
+            }
+        }
+    }
+
+    // Manejar espacios restantes al final del texto
+    if consecutive_spaces > 0 {
+        if *in_indent {
+            for _ in 0..consecutive_spaces {
+                result.push(tab_char);
+            }
+        } else {
+            for _ in 0..consecutive_spaces {
+                result.push(space);
+            }
+        }
+    }
+
+    (result, indent_level)
+}


### PR DESCRIPTION
Indent chars:
It can be a list of characters to iterate through to distinguish the levels of indentation.

command for image example: ` --indent-chars "│,┊"`
![image](https://github.com/user-attachments/assets/baa4dfe1-5966-4246-bbc7-3a48299b7774)

Hidden Characters:

This supports:
- tab
- space
- end of line

command for image example: `--hidden-chars "space:·,tab:»,eol:¶"`
![image](https://github.com/user-attachments/assets/3e8473a1-26cd-4495-95b3-9a70f095a411)
