### PR TITLE
fix(nix): Lock rust version and its hash

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -26,7 +26,7 @@ in
     # fenix: rustup replacement for reproducible builds
     toolchain = fenix.${system}.fromToolchainFile {
       file = ./../rust-toolchain.toml;
-      sha256 = "sha256-yMuSb5eQPO/bHv+Bcf/US8LVMbf/G/0MSfiPwBhiPpk=";
+      sha256 = "sha256-Qxt8XAuaUR2OMdKbN4u8dBJOhSHxS+uS06Wl9+flVEk=";
     };
 
     # crane: cargo and artifacts manager

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "stable"
+channel = "1.88.0"
 profile = "minimal"
 components = ["rustc", "cargo", "clippy", "rustfmt", "rust-std"]


### PR DESCRIPTION
As Rust keeps releasing new versions, it is better to have locked the one that is used for SSS releases.
The Rust version I selected is 1.88.0 because it is the last stable release.